### PR TITLE
feat: Add Amazon Nova Sonic as alternative transcription backend

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5810605625720742b82334cf959ca62545b73d079d7abbc0a9ba17f8a7e2e390",
+  "originHash" : "70576c4df8455c4cf60eb2f0d2686c3898751a6e368c7720a72cc05bde63a5fd",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -116,6 +116,15 @@
       "state" : {
         "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Sources/AudioToText/AppController.swift
+++ b/Sources/AudioToText/AppController.swift
@@ -1,5 +1,9 @@
 import AppKit
 
+protocol TranscriptionService: Sendable {
+    func transcribe(audioData: Data, sampleRateHz: Int) async throws -> String
+}
+
 enum AppState {
     case idle
     case starting
@@ -10,17 +14,17 @@ enum AppState {
 final class AppController {
     private let overlay: OverlayPanel
     private let recorder: AudioRecorder
-    private let transcriber: Transcriber
-    private let textCleaner: TextCleaner
+    private let transcriptionService: any TranscriptionService
+    private let textCleaner: TextCleaner?
     private var state: AppState = .idle
     private var transcriptionTask: Task<Void, Never>?
     private var timeoutTask: Task<Void, Never>?
     private var lastHotkeyTime = DispatchTime(uptimeNanoseconds: 0)
 
-    init(overlay: OverlayPanel, recorder: AudioRecorder, transcriber: Transcriber, textCleaner: TextCleaner) {
+    init(overlay: OverlayPanel, recorder: AudioRecorder, transcriptionService: any TranscriptionService, textCleaner: TextCleaner?) {
         self.overlay = overlay
         self.recorder = recorder
-        self.transcriber = transcriber
+        self.transcriptionService = transcriptionService
         self.textCleaner = textCleaner
     }
 
@@ -86,13 +90,13 @@ final class AppController {
         let sampleRate = recorder.sampleRate
         print("[\(logTS())] [AppController] Using sample rate: \(sampleRate) Hz")
         let overlay = self.overlay
-        let transcriber = self.transcriber
+        let transcriptionService = self.transcriptionService
         let textCleaner = self.textCleaner
 
         transcriptionTask = Task { @MainActor [weak self] in
             defer { self?.timeoutTask?.cancel() }
             do {
-                let rawText = try await transcriber.transcribe(
+                let rawText = try await transcriptionService.transcribe(
                     audioData: audioData,
                     sampleRateHz: sampleRate
                 )
@@ -100,14 +104,16 @@ final class AppController {
                 guard !Task.isCancelled else { return }
 
                 print("Transcription result:", rawText)
-                overlay.updateStatus("Cleaning up...")
 
                 var finalText = rawText
-                do {
-                    finalText = try await textCleaner.clean(rawText: rawText)
-                    print("Cleaned text:", finalText)
-                } catch {
-                    print("Text cleanup failed (using raw text):", error)
+                if let textCleaner = textCleaner {
+                    overlay.updateStatus("Cleaning up...")
+                    do {
+                        finalText = try await textCleaner.clean(rawText: rawText)
+                        print("Cleaned text:", finalText)
+                    } catch {
+                        print("Text cleanup failed (using raw text):", error)
+                    }
                 }
 
                 guard !Task.isCancelled else { return }

--- a/Sources/AudioToText/NovaSonicTranscriber.swift
+++ b/Sources/AudioToText/NovaSonicTranscriber.swift
@@ -1,0 +1,290 @@
+import AWSBedrockRuntime
+import Foundation
+
+enum NovaSonicError: Error, CustomStringConvertible {
+    case missingEnvironmentVariable(String)
+    case noSpeechDetected
+    case streamError(String)
+
+    var description: String {
+        switch self {
+        case .missingEnvironmentVariable(let name):
+            return "Required environment variable \(name) is not set"
+        case .noSpeechDetected:
+            return "No speech detected in audio"
+        case .streamError(let msg):
+            return "Nova Sonic stream error: \(msg)"
+        }
+    }
+}
+
+final class NovaSonicTranscriber: @unchecked Sendable, TranscriptionService {
+    private let client: BedrockRuntimeClient
+    private let modelId = "amazon.nova-sonic-v1:0"
+
+    init() throws {
+        let env = ProcessInfo.processInfo.environment
+        for key in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"] {
+            guard env[key] != nil else {
+                throw NovaSonicError.missingEnvironmentVariable(key)
+            }
+        }
+        let region = env["AWS_REGION"]!
+        self.client = try BedrockRuntimeClient(region: region)
+    }
+
+    func transcribe(audioData: Data, sampleRateHz: Int) async throws -> String {
+        let resampledAudio = resampleTo16kHz(audioData: audioData, fromSampleRate: sampleRateHz)
+        print("[\(logTS())] [NovaSonic] Resampled audio: \(audioData.count) bytes @ \(sampleRateHz)Hz → \(resampledAudio.count) bytes @ 16000Hz")
+
+        let promptName = UUID().uuidString
+        let systemContentName = UUID().uuidString
+        let audioContentName = UUID().uuidString
+
+        let inputStream = AsyncThrowingStream<BedrockRuntimeClientTypes.InvokeModelWithBidirectionalStreamInput, Error> { continuation in
+            // 1. Session start
+            let sessionStartEvent = self.buildEvent([
+                "event": [
+                    "sessionStart": [
+                        "inferenceConfiguration": [
+                            "maxTokens": 1024,
+                            "topP": 0.95,
+                            "temperature": 0.1
+                        ]
+                    ]
+                ]
+            ])
+            continuation.yield(.chunk(BedrockRuntimeClientTypes.BidirectionalInputPayloadPart(bytes: sessionStartEvent)))
+
+            // 2. Prompt start
+            let promptStartEvent = self.buildEvent([
+                "event": [
+                    "promptStart": [
+                        "promptName": promptName,
+                        "textOutputConfiguration": [
+                            "mediaType": "text/plain"
+                        ],
+                        "audioOutputConfiguration": [
+                            "mediaType": "audio/lpcm",
+                            "sampleRateHertz": 24000,
+                            "sampleSizeBits": 16,
+                            "channelCount": 1,
+                            "voiceId": "matthew",
+                            "encoding": "base64",
+                            "audioType": "SPEECH"
+                        ]
+                    ]
+                ]
+            ])
+            continuation.yield(.chunk(BedrockRuntimeClientTypes.BidirectionalInputPayloadPart(bytes: promptStartEvent)))
+
+            // 3. System prompt: contentStart → textInput → contentEnd
+            let systemContentStart = self.buildEvent([
+                "event": [
+                    "contentStart": [
+                        "promptName": promptName,
+                        "contentName": systemContentName,
+                        "type": "TEXT",
+                        "interactive": false,
+                        "role": "SYSTEM",
+                        "textInputConfiguration": [
+                            "mediaType": "text/plain"
+                        ]
+                    ]
+                ]
+            ])
+            continuation.yield(.chunk(BedrockRuntimeClientTypes.BidirectionalInputPayloadPart(bytes: systemContentStart)))
+
+            let systemPrompt = """
+                You are a speech-to-text transcription assistant. You receive audio input and must transcribe it accurately.
+
+                Rules:
+                - The audio is ALWAYS a speech recording. Transcribe it faithfully.
+                - Remove verbal fillers: umm, uh, um, like, you know, so, basically, actually, I mean, right, okay so.
+                - Fix grammar and punctuation.
+                - Preserve the speaker's original words and meaning exactly — only remove fillers and fix mechanics.
+                - Output ONLY the cleaned transcription text. Nothing else.
+                """
+            let systemTextInput = self.buildEvent([
+                "event": [
+                    "textInput": [
+                        "promptName": promptName,
+                        "contentName": systemContentName,
+                        "content": systemPrompt
+                    ]
+                ]
+            ])
+            continuation.yield(.chunk(BedrockRuntimeClientTypes.BidirectionalInputPayloadPart(bytes: systemTextInput)))
+
+            let systemContentEnd = self.buildEvent([
+                "event": [
+                    "contentEnd": [
+                        "promptName": promptName,
+                        "contentName": systemContentName
+                    ]
+                ]
+            ])
+            continuation.yield(.chunk(BedrockRuntimeClientTypes.BidirectionalInputPayloadPart(bytes: systemContentEnd)))
+
+            // 4. Audio content start
+            let audioContentStart = self.buildEvent([
+                "event": [
+                    "contentStart": [
+                        "promptName": promptName,
+                        "contentName": audioContentName,
+                        "type": "AUDIO",
+                        "interactive": true,
+                        "role": "USER",
+                        "audioInputConfiguration": [
+                            "mediaType": "audio/lpcm",
+                            "sampleRateHertz": 16000,
+                            "sampleSizeBits": 16,
+                            "channelCount": 1,
+                            "audioType": "SPEECH",
+                            "encoding": "base64"
+                        ]
+                    ]
+                ]
+            ])
+            continuation.yield(.chunk(BedrockRuntimeClientTypes.BidirectionalInputPayloadPart(bytes: audioContentStart)))
+
+            // 5. Send audio chunks as base64
+            let chunkSize = 1024  // bytes of raw audio per chunk (512 samples = 32ms at 16kHz)
+            var offset = 0
+            while offset < resampledAudio.count {
+                let end = min(offset + chunkSize, resampledAudio.count)
+                let chunk = resampledAudio.subdata(in: offset..<end)
+                let base64Chunk = chunk.base64EncodedString()
+
+                let audioInputEvent = self.buildEvent([
+                    "event": [
+                        "audioInput": [
+                            "promptName": promptName,
+                            "contentName": audioContentName,
+                            "content": base64Chunk
+                        ]
+                    ]
+                ])
+                continuation.yield(.chunk(BedrockRuntimeClientTypes.BidirectionalInputPayloadPart(bytes: audioInputEvent)))
+                offset = end
+            }
+            print("[\(logTS())] [NovaSonic] Sent \(resampledAudio.count / chunkSize + 1) audio chunks")
+
+            // 6. Audio content end
+            let audioContentEnd = self.buildEvent([
+                "event": [
+                    "contentEnd": [
+                        "promptName": promptName,
+                        "contentName": audioContentName
+                    ]
+                ]
+            ])
+            continuation.yield(.chunk(BedrockRuntimeClientTypes.BidirectionalInputPayloadPart(bytes: audioContentEnd)))
+
+            // 7. Prompt end
+            let promptEnd = self.buildEvent([
+                "event": [
+                    "promptEnd": [
+                        "promptName": promptName
+                    ]
+                ]
+            ])
+            continuation.yield(.chunk(BedrockRuntimeClientTypes.BidirectionalInputPayloadPart(bytes: promptEnd)))
+
+            // 8. Session end
+            let sessionEnd = self.buildEvent([
+                "event": [
+                    "sessionEnd": [:] as [String: String]
+                ]
+            ])
+            continuation.yield(.chunk(BedrockRuntimeClientTypes.BidirectionalInputPayloadPart(bytes: sessionEnd)))
+
+            continuation.finish()
+        }
+
+        let input = InvokeModelWithBidirectionalStreamInput(
+            body: inputStream,
+            modelId: modelId
+        )
+
+        print("[\(logTS())] [NovaSonic] Starting bidirectional stream...")
+        let output = try await client.invokeModelWithBidirectionalStream(input: input)
+
+        // Collect USER-role text output from the response stream
+        var userTranscripts: [String: String] = [:]  // contentId → accumulated text
+        var userContentIds: Set<String> = []
+
+        if let responseStream = output.body {
+            for try await event in responseStream {
+                switch event {
+                case .chunk(let payload):
+                    guard let bytes = payload.bytes else { continue }
+                    guard let json = try? JSONSerialization.jsonObject(with: bytes) as? [String: Any],
+                          let eventData = json["event"] as? [String: Any] else { continue }
+
+                    if let contentStart = eventData["contentStart"] as? [String: Any] {
+                        let role = contentStart["role"] as? String
+                        let type = contentStart["type"] as? String
+                        let contentId = contentStart["contentId"] as? String
+                        if role == "USER", type == "TEXT", let id = contentId {
+                            userContentIds.insert(id)
+                            userTranscripts[id] = ""
+                            print("[\(logTS())] [NovaSonic] User transcription content started: \(id)")
+                        }
+                    } else if let textOutput = eventData["textOutput"] as? [String: Any] {
+                        let role = textOutput["role"] as? String
+                        let contentId = textOutput["contentId"] as? String
+                        let content = textOutput["content"] as? String
+                        if role == "USER", let id = contentId, userContentIds.contains(id), let text = content {
+                            userTranscripts[id] = text
+                        }
+                    } else if let contentEnd = eventData["contentEnd"] as? [String: Any] {
+                        let contentId = contentEnd["contentId"] as? String
+                        if let id = contentId, userContentIds.contains(id) {
+                            print("[\(logTS())] [NovaSonic] User transcription content ended: \(id)")
+                        }
+                    }
+                case .sdkUnknown:
+                    break
+                }
+            }
+        }
+
+        // Join all user transcription texts
+        let text = userTranscripts.values
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        print("[\(logTS())] [NovaSonic] Transcription result: \(text)")
+
+        if text.isEmpty {
+            throw NovaSonicError.noSpeechDetected
+        }
+        return text
+    }
+
+    // MARK: - Helpers
+
+    private func buildEvent(_ dict: [String: Any]) -> Data {
+        return (try? JSONSerialization.data(withJSONObject: dict)) ?? Data()
+    }
+
+    private func resampleTo16kHz(audioData: Data, fromSampleRate: Int) -> Data {
+        guard fromSampleRate != 16000 else { return audioData }
+        let inputSamples = audioData.count / 2  // Int16 = 2 bytes per sample
+        let ratio = Double(fromSampleRate) / 16000.0
+        let outputSamples = Int(Double(inputSamples) / ratio)
+        var output = Data(count: outputSamples * 2)
+        audioData.withUnsafeBytes { inBuf in
+            let inPtr = inBuf.bindMemory(to: Int16.self)
+            output.withUnsafeMutableBytes { outBuf in
+                let outPtr = outBuf.bindMemory(to: Int16.self)
+                for i in 0..<outputSamples {
+                    let srcIndex = min(Int(Double(i) * ratio), inputSamples - 1)
+                    outPtr[i] = inPtr[srcIndex]
+                }
+            }
+        }
+        return output
+    }
+}

--- a/Sources/AudioToText/Transcriber.swift
+++ b/Sources/AudioToText/Transcriber.swift
@@ -15,7 +15,7 @@ enum TranscriberError: Error, CustomStringConvertible {
     }
 }
 
-final class Transcriber: @unchecked Sendable {
+final class Transcriber: @unchecked Sendable, TranscriptionService {
     private let client: TranscribeStreamingClient
 
     init() throws {

--- a/Sources/AudioToText/main.swift
+++ b/Sources/AudioToText/main.swift
@@ -2,25 +2,47 @@ import AppKit
 
 MicPermission.ensureAccess()
 
-print("Initializing AWS Transcribe client...")
-let transcriber: Transcriber
-do {
-    transcriber = try Transcriber()
-} catch {
-    fputs("Failed to initialize transcriber: \(error)\n", stderr)
-    exit(1)
-}
-print("AWS Transcribe client ready.")
+let backend = ProcessInfo.processInfo.environment["TRANSCRIPTION_BACKEND"] ?? "transcribe"
+print("Transcription backend: \(backend)")
 
-print("Initializing Bedrock text cleaner...")
-let textCleaner: TextCleaner
-do {
-    textCleaner = try TextCleaner()
-} catch {
-    fputs("Failed to initialize text cleaner: \(error)\n", stderr)
+let transcriptionService: any TranscriptionService
+let textCleaner: TextCleaner?
+
+switch backend {
+case "nova-sonic":
+    print("Initializing Nova Sonic transcriber...")
+    do {
+        transcriptionService = try NovaSonicTranscriber()
+    } catch {
+        fputs("Failed to initialize Nova Sonic transcriber: \(error)\n", stderr)
+        exit(1)
+    }
+    print("Nova Sonic transcriber ready.")
+    textCleaner = nil
+
+case "transcribe":
+    print("Initializing AWS Transcribe client...")
+    do {
+        transcriptionService = try Transcriber()
+    } catch {
+        fputs("Failed to initialize transcriber: \(error)\n", stderr)
+        exit(1)
+    }
+    print("AWS Transcribe client ready.")
+
+    print("Initializing Bedrock text cleaner...")
+    do {
+        textCleaner = try TextCleaner()
+    } catch {
+        fputs("Failed to initialize text cleaner: \(error)\n", stderr)
+        exit(1)
+    }
+    print("Bedrock text cleaner ready.")
+
+default:
+    fputs("Unknown TRANSCRIPTION_BACKEND: '\(backend)'. Use 'transcribe' or 'nova-sonic'.\n", stderr)
     exit(1)
 }
-print("Bedrock text cleaner ready.")
 
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
@@ -30,7 +52,7 @@ let recorder = AudioRecorder()
 let controller = AppController(
     overlay: overlay,
     recorder: recorder,
-    transcriber: transcriber,
+    transcriptionService: transcriptionService,
     textCleaner: textCleaner
 )
 


### PR DESCRIPTION
Add support for switching between AWS Transcribe + Claude Haiku and Amazon Nova Sonic via the TRANSCRIPTION_BACKEND environment variable. Nova Sonic handles both transcription and text cleanup in a single pass through Bedrock's bidirectional streaming API, eliminating the need for the separate Haiku text cleaner step.